### PR TITLE
Small fixes

### DIFF
--- a/Spent.slnx
+++ b/Spent.slnx
@@ -10,7 +10,6 @@
     <File Path="LICENSE" />
     <File Path="README.md" />
   </Folder>
-  <Project Path="Build.fsproj" />
   <Project Path="src/Spent.fsproj" />
   <Project Path="test/Tests.fsproj" />
 </Solution>

--- a/default.nix
+++ b/default.nix
@@ -73,6 +73,7 @@ in
 
   shell = pkgs.mkShell {
     packages = with pkgs; [
+      just
       npins
       snowflaqe
       fantomas

--- a/default.nix
+++ b/default.nix
@@ -82,5 +82,7 @@ in
     ];
 
     NPINS_DIRECTORY = "nix";
+
+    DOTNET_ROOT = "${dotnet-sdk}/share/dotnet";
   };
 }

--- a/src/Main.fs
+++ b/src/Main.fs
@@ -58,9 +58,7 @@ let argParser: Arg<Command> =
                 }
     }
 
-let gql = GraphqlClient settings.gitlabApi
-
-let getWorkItems (group: string) =
+let getWorkItems (gql: GraphqlClient) (group: string) =
     let input: GetWorkItems.InputVariables = { group = group }
     match gql.GetWorkItems input with
     | Ok epics ->
@@ -88,7 +86,9 @@ let executeCommand (_: Threading.CancellationToken) (command: Command) =
     task {
         Log.Logger <- configureSerilog LogEventLevel.Warning
 
-        let workItems = getWorkItems settings.group
+        let gql = GraphqlClient settings.gitlabApi
+        let workItems = getWorkItems gql settings.group
+
         match command with
         | List args ->
             let workItems =


### PR DESCRIPTION
Changes:
- Add `just` to nix shell
- Set `DOTNET_ROOT`, so you can run the binary from `just bundle-debug` directly
- Stop the cli from erroring silently when credentials are not set
- Remove missing files from slnx 