### PR TITLE
fix(nix): Add passthru shell to for spent executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ A minimal time-tracking tool for logging time in GitLab at the Epic level.
 
 ## Build
 
-```
+```console
 just bundle
 cd dist
 ```
 
 ## NixOS
 
-```
+```console
 nix-build -A default
 cd result/bin
 ./spent --help
@@ -19,13 +19,13 @@ cd result/bin
 
 or
 
-```
-nix-shell -A default default.nix
+```console
+nix-shell -A spent-cli
 spent
 ```
 
 ## Run
 
-1. Log in to gitlab using `glab auth login`
+1. Log in to GitLab using `glab auth login`
 2. Run `spent ls` to list available epics
 2. Log time on epic: `spent time -i 1 -s "stuff" 3h15m`

--- a/default.nix
+++ b/default.nix
@@ -84,5 +84,13 @@ in
     NPINS_DIRECTORY = "nix";
 
     DOTNET_ROOT = "${dotnet-sdk}/share/dotnet";
+
+    passthru = pkgs.lib.mapAttrs (name: value: pkgs.mkShellNoCC (value // { inherit name; })) {
+      spent-cli = {
+        packages = [
+          spent
+        ];
+      };
+    };
   };
 }


### PR DESCRIPTION
Updated readme with new shell name `spent-cli`.

Closese #3 